### PR TITLE
Minor adjustments to let checks pass (at least errors and warnings)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,6 +43,8 @@ Imports:
     msa,
     gglogo,
     Biostrings
+Remotes: 
+    heike/gglogo
 Suggests:
     BiocStyle,
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ClustIRR
 Type: Package
 Title: Clustering of immune receptor repertoires
-Version: 1.9.9
+Version: 1.9.10
 Authors@R: c(
     person("Simo", "Kitanovski", email = "simokitanovski@gmail.com", 
     role = c("aut", "cre"), comment=c(ORCID="0000-0003-2909-5376")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -70,4 +70,4 @@ LinkingTo:
     StanHeaders (>= 2.18.0)
 Remotes: 
     heike/gglogo,
-    url::https://cran.r-project.org/src/contrib/Archive/blaster/blaster_1.0.6.tar.gz
+    blaster=url::https://cran.r-project.org/src/contrib/Archive/blaster/blaster_1.0.6.tar.gz

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -70,4 +70,4 @@ LinkingTo:
     StanHeaders (>= 2.18.0)
 Remotes: 
     heike/gglogo,
-    tamminenlab/blaster
+    url::https://cran.r-project.org/src/contrib/Archive/blaster/blaster_1.0.6.tar.gz

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,8 +43,6 @@ Imports:
     msa,
     gglogo,
     Biostrings
-Remotes: 
-    heike/gglogo
 Suggests:
     BiocStyle,
     knitr,
@@ -70,3 +68,6 @@ LinkingTo:
     RcppParallel (>= 5.0.1),
     rstan (>= 2.18.1),
     StanHeaders (>= 2.18.0)
+Remotes: 
+    heike/gglogo,
+    tamminenlab/blaster

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,8 @@ Description: ClustIRR analyzes repertoires of B- and T-cell receptors. It
     in response to e.g. infection or cancer treatment.
 License: GPL-3 + file LICENSE
 Depends:
-    R (>= 4.3.0)
+    R (>= 4.3.0),
+    gglogo
 Imports:
     blaster,
     future,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -68,8 +68,6 @@ importFrom(tidyr, complete)
 importFrom(ggforce, geom_sina)
 importFrom(scales, pretty_breaks)
 
-importFrom(gglogo)
-
 importFrom(msa, msaClustalOmega)
 importFrom(Biostrings, AAStringSet)
 

--- a/R/graph.R
+++ b/R/graph.R
@@ -222,11 +222,16 @@ get_joint_graph <- function(clust_irrs, cores = 1) {
     rm(igs, ige)
     
     # delete duplicated edges, excluding those between different chains
-    if("chain" %in% names(df_e)) {
-        df_e <- df_e[!duplicated(df_e[, c("from", "to", "chain")]), ]
+    if ("chain" %in% names(df_e)) {
+        key <- data.frame(pmin(df_e$from, df_e$to), 
+                          pmax(df_e$from, df_e$to), 
+                          df_e$chain)
     } else {
-        df_e <- df_e[!duplicated(df_e[, c("from", "to")]), ]
+        key <- data.frame(pmin(df_e$from, df_e$to), 
+                          pmax(df_e$from, df_e$to))
     }
+    
+    df_e <- df_e[!duplicated(key), ]
     
     # build joint graph
     g <- graph_from_data_frame(df_e, directed = FALSE, vertices = df_v)

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -56,3 +56,8 @@ Changes in version 1.9.2 (Dec, 2025)
 Changes in version 1.9.9 (Feb, 2026)
 + get_blosum() bugfix -> identical CDR3 did not form edges in certain cases
 + added test-get_blosum.R 
+
+Changes in version 1.9.10 (Feb, 2026)
++ get_joint_graph() bugfixes 
+ * when clustering both CDR3a/CDR3b, CDR3b edges between-repertoires got deleted
+ * one between-repertoire edge between two clones with double edges was deleted

--- a/man/get_cdr3_motifs.Rd
+++ b/man/get_cdr3_motifs.Rd
@@ -42,10 +42,10 @@ in the CDR3 sequence, with optional gap removal based on the `gap_remove_prob`.
 \examples{
 # Create a mock node summary data frame
 node_summary <- data.frame(
-  community = rep(1, 5),
+  community = rep(1, 4),
   CDR3a = c("CASSLAGTDTQYF", "CASSLAGTDTQYF", "CASSLAGTDTQYF", "CASSLAGTDTQYF"),
   CDR3b = c("CASSLAGTDTQYF", "CASSLAGTDTQYF", "CASSLAGTDTQYF", "CASSLAGTDTQYF"),
-  clone_size = c(100, 150, 200, 50, 300)
+  clone_size = c(100, 150, 200, 50)
 )
 
 # Call the function to generate motif logos for community 1

--- a/man/get_cosine_similarity.Rd
+++ b/man/get_cosine_similarity.Rd
@@ -39,7 +39,7 @@ A list containing two elements:
 }
 \examples{
 # Create a sample matrix
-mat <- matrix(rpois(n=30, lambda = 4), nrow = 5, 
+mat <- matrix(rpois(n=15, lambda = 4), nrow = 5, 
               dimnames = list(NULL, c("A", "B", "C")))
 
 # Compute similarities and plot

--- a/tests/testthat/test-multi-chain-clustering.R
+++ b/tests/testthat/test-multi-chain-clustering.R
@@ -1,0 +1,189 @@
+test_that("clustering two chains - within-repertoire", {
+    
+    # test data
+    data("CDR3ab", package = "ClustIRR")
+    a1 <- data.frame(CDR3a = CDR3ab[1:100, "CDR3a"],
+                     CDR3b = CDR3ab[1:100, "CDR3b"],
+                     clone_size = 1,
+                     sample = "a")
+    a2 <- data.frame(CDR3a = CDR3ab[401:500, "CDR3a"],
+                     CDR3b = CDR3ab[401:500, "CDR3b"],
+                     clone_size = 1,
+                     sample = "a")
+    
+    # insert clones with two identical chains
+    cdr3a <- "CAVEYSGAGSYQLTF"
+    cdr3b <- "CASSQEFGSSYEQYF"
+    a1_cdr3ab <- data.frame(CDR3a = cdr3a,
+                            CDR3b = cdr3b,
+                            clone_size = 135,
+                            sample = "a")
+    a2_cdr3ab <- data.frame(CDR3a = cdr3a,
+                            CDR3b = cdr3b,
+                            clone_size = 230,
+                            sample = "a")
+    
+    # insert big clones that perfectly overlap on cdr3a chain 
+    # set cdr3b of the clones to non-overlapping sequences
+    cdr3a_only <- "CASSSSSSSSSSSSF"
+    a1_cdr3a <- data.frame(CDR3a = cdr3a_only,
+                           CDR3b = "CAGGGGGGGGGGGGF",
+                           clone_size = 500,
+                           sample = "a")
+    a2_cdr3a <- data.frame(CDR3a = cdr3a_only,
+                           CDR3b = "CAQQQQQQQQQQQQF",
+                           clone_size = 300,
+                           sample = "a")
+    
+    # insert big clones that perfectly overlap on cdr3b chain 
+    # set cdr3a of the clones to non-overlapping sequences
+    cdr3b_only <- "CAYYYYYYYYYYYYF"
+    a1_cdr3b <- data.frame(CDR3a = "CAAAAAAAAAAAAAF",
+                           CDR3b = cdr3b_only,
+                           clone_size = 150,
+                           sample = "a")
+    a2_cdr3b <- data.frame(CDR3a = "CAEEEEEEEEEEEEF",
+                           CDR3b = cdr3b_only,
+                           clone_size = 200,
+                           sample = "a")
+    
+    s <- rbind(a1, a1_cdr3ab, a1_cdr3b, a1_cdr3a, 
+               a2, a2_cdr3ab, a2_cdr3b, a2_cdr3a)
+    
+    # run ClustIRR analysis
+    c <- clustirr(s = s)
+    
+    # check nodes
+    df_v <- igraph::as_data_frame(c$graph, what = "vertices")
+    
+    # check that the 2 nodes for each test pair exist in the graph
+    cdr3ab_n <- which(df_v$CDR3b == cdr3b & df_v$CDR3a == cdr3a,)
+    cdr3a_n <- which(df_v$CDR3a == cdr3a_only,)
+    cdr3b_n <- which(df_v$CDR3b == cdr3b_only,)
+    
+    # there should be two clones for each test
+    expect_true(length(cdr3ab_n) == 2)
+    expect_true(length(cdr3a_n) == 2)
+    expect_true(length(cdr3b_n) == 2)
+    
+    # check edges
+    df_e <- igraph::as_data_frame(c$graph, what = "edges")
+    
+    cdr3ab_e_n1 <- df_v$name[cdr3ab_n[1]]
+    cdr3ab_e_n2 <- df_v$name[cdr3ab_n[2]]
+    cdr3ab_e <- df_e[df_e$from == cdr3ab_e_n1 & df_e$to == cdr3ab_e_n2 |
+                         df_e$from == cdr3ab_e_n2 & df_e$to == cdr3ab_e_n1,]
+    
+    cdr3a_e_n1 <- df_v$name[cdr3a_n[1]]
+    cdr3a_e_n2 <- df_v$name[cdr3a_n[2]]
+    cdr3a_e <- df_e[df_e$from == cdr3a_e_n1 & df_e$to == cdr3a_e_n2 |
+                         df_e$from == cdr3a_e_n2 & df_e$to == cdr3a_e_n1,]
+    
+    cdr3b_e_n1 <- df_v$name[cdr3b_n[1]]
+    cdr3b_e_n2 <- df_v$name[cdr3b_n[2]]
+    cdr3b_e <- df_e[df_e$from == cdr3b_e_n1 & df_e$to == cdr3b_e_n2 |
+                        df_e$from == cdr3b_e_n2 & df_e$to == cdr3b_e_n1,]
+    
+    # there should be two edges between the clones with two identical chains
+    # and one edge between each clone pair with one identical chain
+    expect_true(nrow(cdr3ab_e) == 2)
+    expect_true(nrow(cdr3a_e) == 1)
+    expect_true(nrow(cdr3b_e) == 1)
+    
+    
+})
+
+
+test_that("clustering two chains - between-repertoire", {
+    
+    # test data
+    data("CDR3ab", package = "ClustIRR")
+    a <- data.frame(CDR3a = CDR3ab[1:100, "CDR3a"],
+                     CDR3b = CDR3ab[1:100, "CDR3b"],
+                     clone_size = 1,
+                     sample = "a")
+    b <- data.frame(CDR3a = CDR3ab[401:500, "CDR3a"],
+                     CDR3b = CDR3ab[401:500, "CDR3b"],
+                     clone_size = 1,
+                     sample = "b")
+    
+    # insert clones with two identical chains
+    cdr3a <- "CAVEYSGAGSYQLTF"
+    cdr3b <- "CASSQEFGSSYEQYF"
+    a_cdr3ab <- data.frame(CDR3a = cdr3a,
+                            CDR3b = cdr3b,
+                            clone_size = 135,
+                            sample = "a")
+    b_cdr3ab <- data.frame(CDR3a = cdr3a,
+                            CDR3b = cdr3b,
+                            clone_size = 230,
+                            sample = "b")
+    
+    # insert big clones that perfectly overlap on cdr3a chain 
+    # set cdr3b of the clones to non-overlapping sequences
+    cdr3a_only <- "CASSSSSSSSSSSSF"
+    a_cdr3a <- data.frame(CDR3a = cdr3a_only,
+                           CDR3b = "CAGGGGGGGGGGGGF",
+                           clone_size = 500,
+                           sample = "a")
+    b_cdr3a <- data.frame(CDR3a = cdr3a_only,
+                           CDR3b = "CAQQQQQQQQQQQQF",
+                           clone_size = 300,
+                           sample = "b")
+    
+    # insert big clones that perfectly overlap on cdr3b chain 
+    # set cdr3a of the clones to non-overlapping sequences
+    cdr3b_only <- "CAYYYYYYYYYYYYF"
+    a_cdr3b <- data.frame(CDR3a = "CAAAAAAAAAAAAAF",
+                           CDR3b = cdr3b_only,
+                           clone_size = 150,
+                           sample = "a")
+    b_cdr3b <- data.frame(CDR3a = "CAEEEEEEEEEEEEF",
+                           CDR3b = cdr3b_only,
+                           clone_size = 200,
+                           sample = "b")
+    
+    s <- rbind(a, a_cdr3ab, a_cdr3b, a_cdr3a, b, b_cdr3ab, b_cdr3b, b_cdr3a)
+    
+    # run ClustIRR analysis
+    c <- clustirr(s = s)
+    
+    # check nodes
+    df_v <- igraph::as_data_frame(c$graph, what = "vertices")
+    
+    # check that the 2 nodes for each test pair exist in the graph
+    cdr3ab_n <- which(df_v$CDR3b == cdr3b & df_v$CDR3a == cdr3a,)
+    cdr3a_n <- which(df_v$CDR3a == cdr3a_only,)
+    cdr3b_n <- which(df_v$CDR3b == cdr3b_only,)
+    
+    # there should be two clones for each test
+    expect_true(length(cdr3ab_n) == 2)
+    expect_true(length(cdr3a_n) == 2)
+    expect_true(length(cdr3b_n) == 2)
+    
+    # check edges
+    df_e <- igraph::as_data_frame(c$graph, what = "edges")
+    
+    cdr3ab_e_n1 <- df_v$name[cdr3ab_n[1]]
+    cdr3ab_e_n2 <- df_v$name[cdr3ab_n[2]]
+    cdr3ab_e <- df_e[df_e$from == cdr3ab_e_n1 & df_e$to == cdr3ab_e_n2 |
+                         df_e$from == cdr3ab_e_n2 & df_e$to == cdr3ab_e_n1,]
+    
+    cdr3a_e_n1 <- df_v$name[cdr3a_n[1]]
+    cdr3a_e_n2 <- df_v$name[cdr3a_n[2]]
+    cdr3a_e <- df_e[df_e$from == cdr3a_e_n1 & df_e$to == cdr3a_e_n2 |
+                        df_e$from == cdr3a_e_n2 & df_e$to == cdr3a_e_n1,]
+    
+    cdr3b_e_n1 <- df_v$name[cdr3b_n[1]]
+    cdr3b_e_n2 <- df_v$name[cdr3b_n[2]]
+    cdr3b_e <- df_e[df_e$from == cdr3b_e_n1 & df_e$to == cdr3b_e_n2 |
+                        df_e$from == cdr3b_e_n2 & df_e$to == cdr3b_e_n1,]
+    
+    # there should be two edges between the clones with two identical chains
+    # and one edge between each clone pair with one identical chain
+    expect_true(nrow(cdr3ab_e) == 2)
+    expect_true(nrow(cdr3a_e) == 1)
+    expect_true(nrow(cdr3b_e) == 1)
+    
+    
+})

--- a/vignettes/User_manual_groups.Rmd
+++ b/vignettes/User_manual_groups.Rmd
@@ -4,8 +4,7 @@ receptor repertoires with ClustIRR"
 output:
     BiocStyle::html_document
 vignette: >
-    %\VignetteIndexEntry{Finding **biological condition**-specific changes 
-    in T- and B-cell receptor repertoires with ClustIRR}
+    %\VignetteIndexEntry{Finding biological condition-specific changes in T- and B-cell receptor repertoires with ClustIRR}
     %\VignetteEncoding{UTF-8}
     %\VignetteEngine{knitr::rmarkdown}
 editor_options: 


### PR DESCRIPTION
- Fixed examples in get_cosine_similarity and get_cdr3_motifs
- Temporary fix: added gglogo to NAMESPACE to avoid some (potentially _gglogo_ package inherent) bug with _ggfortify()_ depending on _data(aacids)_ to sit in the global Environment
- Fixed vignette formatting of User manual groups

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Package updated to v1.9.10; new dependency added (gglogo) and remote sources listed.

* **Bug Fixes**
  * Fixed edge-deletion issues in multi-chain clustering to preserve between-repertoire edges.

* **Tests**
  * Added unit tests validating multi-chain clustering behavior within and between repertoires.

* **Documentation**
  * Updated examples and vignette header text for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->